### PR TITLE
set TAGGED_RELEASE_BANNER to a ppa-specific identifier

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -3,6 +3,7 @@
 include /usr/share/dpkg/default.mk
 
 COMMON_FLAGS = prefix=debian/tmp/usr VERBOSE=1 MULTIARCH_INSTALL=1 NO_GIT=1 USE_BLAS64=0 \
+	TAGGED_RELEASE_BANNER="Ubuntu ppa:staticfloat/juliareleases build" \
 	USE_SYSTEM_MPFR=1 USE_SYSTEM_GMP=1 USE_SYSTEM_FFTW=1 USE_SYSTEM_CURL=1
 	
 # Set platform-specific flags


### PR DESCRIPTION
does this repo get used for both juliareleases and julianightlies?
any way to distinguish between them in this file?

@staticfloat I guess I should have done this instead of https://github.com/staticfloat/julia-debian/pull/2